### PR TITLE
fix: don't modify array prototype

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,12 @@
 // Create a handy array function
-Array.prototype.in_array = function ( obj ) {
-    var len = this.length;
+function in_array( arr, obj ) {
+    if (typeof arr.includes === 'function') {
+        arr.includes(obj);
+    }
+
+    var len = arr.length;
     for ( var x = 0 ; x <= len ; x++ ) {
-        if ( this[x] == obj ) return true;
+        if ( arr[x] == obj ) return true;
     }
     return false;
 }
@@ -86,7 +90,7 @@ exports.generate = function (style) {
     var style = (style == null || (style !== 1 && style !== 2)) ? 1 : style;
 
     // Generate group1
-    while( group1 == '' || notAllowed.in_array(group1) ) {
+    while( group1 == '' || in_array(notAllowed, group1) ) {
         // First letter
         randomArrayIndex = Math.floor(Math.random() * firstAllowed.length);
         group1 = firstAllowed[ randomArrayIndex ];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fake-nino",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Validate and generate fake UK national insurance numbers (NINO)",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
I ran into an issue where the `in_array` function was conflicting with another package, and causing errors in that package. It is generally bad practice to modify the Array prototype for this reason. This PR doesn't modify the Array prototype and just creates a function instead. This will also use the built-in `includes` function if it exists (ie. Node 6+). Falls back to custom implementation in case anyone is still using very old versions of Node.