### PR TITLE
fix: Set group variables in generate function

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,14 +11,6 @@ function in_array( arr, obj ) {
     return false;
 }
 
-// Setup our groups
-var group1 = '';
-var group2 = '';
-var group3 = '';
-var group4 = '';
-var group5 = '';
-var randomArrayIndex = '';
-
 // Some combinations are not allowed
 var notAllowed = new Array(
     'GB',
@@ -89,6 +81,14 @@ exports.generate = function (style) {
     // Set a default value for style and make sure it is valid
     var style = (style == null || (style !== 1 && style !== 2)) ? 1 : style;
 
+    // Setup our groups
+    var group1 = '';
+    var group2 = '';
+    var group3 = '';
+    var group4 = '';
+    var group5 = '';
+    var randomArrayIndex = '';
+
     // Generate group1
     while( group1 == '' || in_array(notAllowed, group1) ) {
         // First letter
@@ -126,7 +126,7 @@ exports.generate = function (style) {
 }
 
 exports.validate = function (nino) {
-        var regex = /^[A-CEGHJ-PR-TW-Z][A-CEGHJ-NPR-TW-Z] ?[0-9]{2} ?[0-9]{2} ?[0-9]{2} ?[ABCD]?/;
+    var regex = /^[A-CEGHJ-PR-TW-Z][A-CEGHJ-NPR-TW-Z] ?[0-9]{2} ?[0-9]{2} ?[0-9]{2} ?[ABCD]?/;
 
     if (nino.match(regex)) {
         regex = /^(GB)|^(BG)|^(NK)|^(KN)|^(TN)|^(NT)|^(ZZ)/;


### PR DESCRIPTION
### Why
The variables for building the NINO out of individual groups were set in the global scope, and part of the `generate` function's closure. This is fine if you only generate one time, but subsequent calls to this function will use the same prefix. We have some additional checking to exclude [administrative prefixes](https://en.wikipedia.org/wiki/National_Insurance_number#Administrative_numbers) so if we encounter one of these, we generate a new one.

### What
- Move `group` variable initialization to within the `generate` method

Before:
```javascript
> nino.generate()
'JK955070B'
> nino.generate()
'JK345604B'
> nino.generate()
'JK952040B'
> nino.generate()
'JK308585C'
> nino.generate()
'JK661964B'
```

After:

```javascript
> nino.generate()
'LC589570'
> nino.generate()
'XL346551B'
> nino.generate()
'OM039409C'
> nino.generate()
'XM139504A'
> nino.generate()
'GS688968'
```